### PR TITLE
Some small changes to match latest progess in pluggable discovery

### DIFF
--- a/SerialDiscovery.c
+++ b/SerialDiscovery.c
@@ -58,7 +58,7 @@ void add(struct udev_device *dev)
 		printf("    \"pid\": \"0x%s\"\n", pid);
 		printf("  },\n");
 	}
-	printf("  \"protocol\": \"Serial Device\"\n}\n"); // probably not correct
+	printf("  \"protocol\": \"serial\"\n}\n");
 	fflush(stdout);
 }
 

--- a/SerialDiscovery.c
+++ b/SerialDiscovery.c
@@ -56,7 +56,8 @@ void add(struct udev_device *dev)
 		printf("      \"pid\": \"0x%s\"\n", pid);
 		printf("    },\n");
 	}
-	printf("    \"protocol\": \"serial\"\n");
+	printf("    \"protocol\": \"serial\",\n");
+	printf("    \"protocolLabel\": \"USB Serial Port\"\n");
 	printf("  }\n");
 	printf("}\n");
 	fflush(stdout);

--- a/SerialDiscovery.c
+++ b/SerialDiscovery.c
@@ -26,13 +26,7 @@ void add(struct udev_device *dev)
 	printf("{\n");
 	printf("  \"eventType\": \"add\",\n");
 	printf("  \"port\": {\n");
-	// Prepend an underscore '_' to the address field, so our address
-	// names will be unique and not conflict with those from normal
-	// SerialDiscovery.java.  Long-term, we're going to need to figure
-	// out a way for the Arduino IDE to deal with non-unique address
-	// names.  Maybe also track which discoverer, so they only need to
-	// be unique within one discoverer instance?
-	printf("    \"address\": \"_%s\",\n", devnode);
+	printf("    \"address\": \"%s\",\n", devnode);
 	if (name) {
 		printf("    \"label\": \"%s (%s)\",\n", devnode, name);
 		printf("    \"boardName\": \"%s\",\n", name);
@@ -77,7 +71,7 @@ void del(struct udev_device *dev)
 	printf("{\n");
 	printf("  \"eventType\": \"remove\",\n");
 	printf("  \"port\": {\n");
-	printf("    \"address\": \"_%s\"\n", devnode);
+	printf("    \"address\": \"%s\"\n", devnode);
 	printf("  }\n");
 	printf("}\n");
 	fflush(stdout);

--- a/SerialDiscovery.c
+++ b/SerialDiscovery.c
@@ -36,12 +36,12 @@ void add(struct udev_device *dev)
 	if (vid || pid || ser) {
 		printf("    \"prefs\": {\n");
 		if (vid) {
-			printf("      \"vendorId\": \"%s\"", vid);
+			printf("      \"vendorId\": \"0x%s\"", vid);
 			if (pid || ser) printf(",");
 			printf("\n");
 		}
 		if (pid) {
-			printf("      \"productId\": \"%s\"", pid);
+			printf("      \"productId\": \"0x%s\"", pid);
 			if (ser) printf(",");
 			printf("\n");
 		}

--- a/SerialDiscovery.c
+++ b/SerialDiscovery.c
@@ -22,43 +22,49 @@ void add(struct udev_device *dev)
 	pid = udev_device_get_sysattr_value(pdev, "idProduct");
 	ser = udev_device_get_sysattr_value(pdev, "serial");
 	name = udev_device_get_sysattr_value(pdev, "product");
+
+	printf("{\n");
+	printf("  \"eventType\": \"add\",\n");
+	printf("  \"port\": {\n");
 	// Prepend an underscore '_' to the address field, so our address
 	// names will be unique and not conflict with those from normal
 	// SerialDiscovery.java.  Long-term, we're going to need to figure
 	// out a way for the Arduino IDE to deal with non-unique address
 	// names.  Maybe also track which discoverer, so they only need to
 	// be unique within one discoverer instance?
-	printf("{\n  \"eventType\": \"add\",\n  \"address\": \"_%s\",\n", devnode);
+	printf("    \"address\": \"_%s\",\n", devnode);
 	if (name) {
-		printf("  \"label\": \"%s (%s)\",\n", devnode, name);
-		printf("  \"boardName\": \"%s\",\n", name);
+		printf("    \"label\": \"%s (%s)\",\n", devnode, name);
+		printf("    \"boardName\": \"%s\",\n", name);
 	} else {
-		printf("  \"label\": \"%s\",\n", devnode);
+		printf("    \"label\": \"%s\",\n", devnode);
 	}
 	if (vid || pid || ser) {
-		printf("  \"prefs\": {\n");
+		printf("    \"prefs\": {\n");
 		if (vid) {
-			printf("    \"vendorId\": \"%s\"", vid);
+			printf("      \"vendorId\": \"%s\"", vid);
 			if (pid || ser) printf(",");
 			printf("\n");
 		}
 		if (pid) {
-			printf("    \"productId\": \"%s\"", pid);
+			printf("      \"productId\": \"%s\"", pid);
 			if (ser) printf(",");
 			printf("\n");
 		}
 		if (ser) {
-			printf("    \"serialNumber\": \"%s\"\n", ser);
+			printf("      \"serialNumber\": \"%s\"\n", ser);
 		}
-		printf("  },\n");
+		printf("    },\n");
 	}
 	if (vid && pid) {
-		printf("  \"identificationPrefs\": {\n");
-		printf("    \"vid\": \"0x%s\",\n", vid);
-		printf("    \"pid\": \"0x%s\"\n", pid);
-		printf("  },\n");
+		printf("    \"identificationPrefs\": {\n");
+		printf("      \"vid\": \"0x%s\",\n", vid);
+		printf("      \"pid\": \"0x%s\"\n", pid);
+		printf("    },\n");
 	}
-	printf("  \"protocol\": \"serial\"\n}\n");
+	printf("    \"protocol\": \"serial\"\n");
+	printf("  }\n");
+	printf("}\n");
 	fflush(stdout);
 }
 
@@ -68,7 +74,12 @@ void del(struct udev_device *dev)
 
 	devnode = udev_device_get_devnode(dev);
 	if (!devnode) return;
-	printf("{\n  \"eventType\": \"remove\",\n  \"address\": \"_%s\"\n}\n", devnode);
+	printf("{\n");
+	printf("  \"eventType\": \"remove\",\n");
+	printf("  \"port\": {\n");
+	printf("    \"address\": \"_%s\"\n", devnode);
+	printf("  }\n");
+	printf("}\n");
 	fflush(stdout);
 }
 


### PR DESCRIPTION
- use `serial` as protocol field and `USB Serial Port` as `protocolLabel` (this result in two different groups in the port list of the IDE)
- removed the `_` workaround to keep correct port selection, this will be fixed in the IDE
- port metadata are now grouped in their own field `port`
- use `0x...` prefix for all vids/pids fields

The result JSON report is now:

```
{
  "eventType": "add",
  "port": {
    "address": "/dev/ttyACM0",
    "label": "/dev/ttyACM0",
    "prefs": {
      "vendorId": "0x2341",
      "productId": "0x0043",
      "serialNumber": "85235353137351018160"
    },
    "identificationPrefs": {
      "vid": "0x2341",
      "pid": "0x0043"
    },
    "protocol": "serial",
    "protocolLabel": "USB Serial Port"
  }
}
```